### PR TITLE
Fix getPeopleProfile method

### DIFF
--- a/lib/resources/WebsitePeople.js
+++ b/lib/resources/WebsitePeople.js
@@ -85,7 +85,7 @@ function WebsitePeople(crisp) {
    * @return Promise
    */
   this.getPeopleProfile = function(websiteId, peopleId) {
-    return crisp.get(crisp._prepareRestUrl(["website", websiteId, "people", peopleId]), {}, {});
+    return crisp.get(crisp._prepareRestUrl(["website", websiteId, "people", "profile", peopleId]), {}, {});
   };
 
   /**


### PR DESCRIPTION
should be 

https://api.crisp.chat/v1/website/websiteId/people/profile/peopleId

but was sending

https://api.crisp.chat/v1/website/websiteId/people/peopleId