### PR TITLE
Fix before_timestamp in getMessages

### DIFF
--- a/lib/resources/WebsiteConversations.js
+++ b/lib/resources/WebsiteConversations.js
@@ -151,7 +151,7 @@ function WebsiteConversations(crisp) {
    */
   this.getMessages = function(websiteId, sessionId, query) {
     return crisp.get(crisp._prepareRestUrl(
-    ["website", websiteId, "conversation", sessionId, "messages"]));
+    ["website", websiteId, "conversation", sessionId, "messages"]), query);
   };
 
   /**


### PR DESCRIPTION
The query variable is unused in getMessages.