### PR TITLE
_request rejection with statusCode

### DIFF
--- a/lib/crisp.js
+++ b/lib/crisp.js
@@ -324,7 +324,7 @@ Crisp.prototype = {
   /**
    * get a ressource
    * @memberof Crisp
-   * @method _get
+   * @method _request
    */
   _request : function(resource, method, query, body, resolve, reject) {
     var _parameters = {
@@ -363,10 +363,10 @@ Crisp.prototype = {
         // Request error?
         if (!response.statusCode) {
           return reject({
-            reason  : "error",
-            message : "internal_error",
-
-            data    : {
+            reason     : "error",
+            message    : "internal_error",
+	    statusCode : 500,
+            data       : {
               namespace : "request",
               message   : ("Got request error: " + (response.name || "Unknown"))
             }
@@ -376,10 +376,10 @@ Crisp.prototype = {
         // Response error?
         if (response.statusCode >= 400) {
           return reject({
-            reason  : "error",
-            message : ((response.body || {}).reason || "http_error"),
-
-            data    : {
+            reason     : "error",
+            message    : ((response.body || {}).reason || "http_error"),
+	    statusCode : response.statusCode,
+            data       : {
               namespace : "response",
               message   : ("Got response status: " + response.statusCode)
             }


### PR DESCRIPTION
It would be really convenient to have the result status code in response, for instance to deal with the 429.