### PR TITLE
Remove extra query parameter encoding with findWithSearch

### DIFF
--- a/lib/resources/WebsiteConversations.js
+++ b/lib/resources/WebsiteConversations.js
@@ -58,7 +58,7 @@ function WebsiteConversations(crisp) {
       var parameterValue = searchParams[parameter[0]];
 
       if (parameterValue) {
-        query[parameter[1]] = encodeURIComponent(parameterValue);
+        query[parameter[1]] = parameterValue;
       }
     });
 


### PR DESCRIPTION
Fixes #32 