### PR TITLE
Fix resources naming case

### DIFF
--- a/lib/services/Bucket.js
+++ b/lib/services/Bucket.js
@@ -16,7 +16,7 @@
  */
 function Bucket() {
   this._resources = [
-    "BucketUrl"
+    "BucketURL"
   ];
 }
 


### PR DESCRIPTION
File in `lib/resources` is called `BucketURL.js`, so the resource specification needs to have the same case name.